### PR TITLE
Convert check_host_reachable from sync socket to async

### DIFF
--- a/src/pooldose/__main__.py
+++ b/src/pooldose/__main__.py
@@ -75,7 +75,7 @@ async def run_device_analyzer(host: str, use_ssl: bool, port: int, show_all: boo
     try:
         # Test connection
         print("Testing connection...")
-        if not handler.check_host_reachable():
+        if not await handler.check_host_reachable():
             print("Host not reachable!")
             return
         print("Host is reachable")

--- a/src/pooldose/request_handler.py
+++ b/src/pooldose/request_handler.py
@@ -115,7 +115,7 @@ class RequestHandler:  # pylint: disable=too-many-instance-attributes
             bool: True if reachable, False otherwise.
         """
         try:
-            reader, writer = await asyncio.wait_for(
+            _, writer = await asyncio.wait_for(
                 asyncio.open_connection(self.host, self.port),
                 timeout=self.timeout,
             )

--- a/src/pooldose/request_handler.py
+++ b/src/pooldose/request_handler.py
@@ -4,7 +4,6 @@ import asyncio
 import json
 import logging
 import re
-import socket
 import ssl
 from typing import Any, Optional, Tuple, Union, List, Dict
 
@@ -85,7 +84,7 @@ class RequestHandler:  # pylint: disable=too-many-instance-attributes
         Returns:
             RequestStatus: SUCCESS if connected successfully, otherwise appropriate error status.
         """
-        if not self.check_host_reachable():
+        if not await self.check_host_reachable():
             return RequestStatus.HOST_UNREACHABLE
 
         params = await self._get_core_params()
@@ -108,7 +107,7 @@ class RequestHandler:  # pylint: disable=too-many-instance-attributes
         """Get the last payload sent to the device (if debug_payload is enabled)."""
         return self._last_payload
 
-    def check_host_reachable(self) -> bool:
+    async def check_host_reachable(self) -> bool:
         """
         Check if the host is reachable on the configured port.
 
@@ -116,9 +115,14 @@ class RequestHandler:  # pylint: disable=too-many-instance-attributes
             bool: True if reachable, False otherwise.
         """
         try:
-            with socket.create_connection((self.host, self.port), timeout=self.timeout):
-                return True
-        except (socket.error, socket.timeout) as err:
+            reader, writer = await asyncio.wait_for(
+                asyncio.open_connection(self.host, self.port),
+                timeout=self.timeout,
+            )
+            writer.close()
+            await writer.wait_closed()
+            return True
+        except (OSError, asyncio.TimeoutError) as err:
             _LOGGER.error("Host %s not reachable on port %d: %s", self.host, self.port, err)
             return False
 

--- a/tests/test_ssl_support.py
+++ b/tests/test_ssl_support.py
@@ -83,27 +83,31 @@ class TestRequestHandlerSSL:
         url = handler._build_url("/api/v1/test")
         assert url == "https://example.com/api/v1/test"
 
-    @patch('socket.create_connection')
-    def test_host_reachable_custom_port(self, mock_socket):
+    @pytest.mark.asyncio
+    @patch('asyncio.open_connection')
+    async def test_host_reachable_custom_port(self, mock_open):
         """Test host reachability check uses configured port."""
-        mock_socket.return_value.__enter__ = Mock()
-        mock_socket.return_value.__exit__ = Mock()
+        mock_writer = Mock()
+        mock_writer.close = Mock()
+        mock_writer.wait_closed = AsyncMock()
+        mock_open.return_value = (AsyncMock(), mock_writer)
 
         handler = RequestHandler("example.com", port=8080)
-        result = handler.check_host_reachable()
+        result = await handler.check_host_reachable()
 
-        mock_socket.assert_called_once_with(("example.com", 8080), timeout=10)
+        mock_open.assert_called_once_with("example.com", 8080)
         assert result is True
 
-    @patch('socket.create_connection')
-    def test_host_unreachable_custom_port(self, mock_socket):
+    @pytest.mark.asyncio
+    @patch('asyncio.open_connection')
+    async def test_host_unreachable_custom_port(self, mock_open):
         """Test host unreachable with custom port."""
-        mock_socket.side_effect = OSError("Connection failed")
+        mock_open.side_effect = OSError("Connection failed")
 
         handler = RequestHandler("example.com", port=8443, use_ssl=True)
-        result = handler.check_host_reachable()
+        result = await handler.check_host_reachable()
 
-        mock_socket.assert_called_once_with(("example.com", 8443), timeout=10)
+        mock_open.assert_called_once_with("example.com", 8443)
         assert result is False
 
     def test_ssl_context_configuration(self):


### PR DESCRIPTION
## Convert check_host_reachable from blocking socket to async

### Description

`check_host_reachable()` used a synchronous `socket.create_connection()` call, which blocks the asyncio event loop for up to the full timeout duration when a host is unreachable. This is problematic because the method is called from the async `connect()` method — blocking the event loop prevents other coroutines from running.

### Changes

**src/pooldose/request_handler.py**
- Converted `check_host_reachable()` from `def` to `async def`
- Replaced `socket.create_connection()` with `asyncio.open_connection()` wrapped in `asyncio.wait_for()` for timeout support
- Properly closes the writer after a successful connection check
- Catches `OSError` and `asyncio.TimeoutError` instead of `socket.error` and `socket.timeout`
- Removed unused `import socket`
- Updated `connect()` to `await` the call

**src/pooldose/__main__.py**
- Updated `check_host_reachable()` call to use `await`

**tests/test_ssl_support.py**
- Converted `test_host_reachable_custom_port` and `test_host_unreachable_custom_port` to async tests
- Replaced `socket.create_connection` mock with `asyncio.open_connection` mock using proper `AsyncMock` for writer

### Test results

All **144 tests pass** with 0 warnings.