### PR TITLE
Extract hard-coded retry delay to _RETRY_DELAY constant

### DIFF
--- a/src/pooldose/client.py
+++ b/src/pooldose/client.py
@@ -24,6 +24,8 @@ _LOGGER = logging.getLogger(__name__)
 
 API_VERSION_SUPPORTED = "v1/"
 
+_RETRY_DELAY = 0.5
+
 class PooldoseClient:
     """
     Async client for SEKO Pooldose API.
@@ -164,7 +166,7 @@ class PooldoseClient:
                 self.device_info["MODEL_ID"] = device.get("PRODUCT_CODE")
                 self.device_info["FW_VERSION"] = device.get("FW_REL")
                 self.device_info["FW_CODE"] = device.get("FW_CODE")
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(_RETRY_DELAY)
 
         # Load mapping information
         model_id = self.device_info.get("MODEL_ID")
@@ -186,7 +188,7 @@ class PooldoseClient:
             # Only include WiFi key if explicitly requested
             if self._include_sensitive_data:
                 self.device_info["WIFI_KEY"] = wifi_station.get("KEY")
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(_RETRY_DELAY)
 
         # Access point info
         status, access_point = await self._request_handler.get_access_point()
@@ -197,7 +199,7 @@ class PooldoseClient:
             # Only include AP key if explicitly requested
             if self._include_sensitive_data:
                 self.device_info["AP_KEY"] = access_point.get("KEY")
-        await asyncio.sleep(0.5)
+        await asyncio.sleep(_RETRY_DELAY)
 
         # Network info
         status, network_info = await self._request_handler.get_network_info()


### PR DESCRIPTION
## Extract hard-coded retry delay to named constant

### Description

The `asyncio.sleep(0.5)` calls in `client.py` used a magic number repeated 3 times. This replaces them with a single `_RETRY_DELAY` constant for better readability and a single point of change.

### Changes

**src/pooldose/client.py**
- Added `_RETRY_DELAY = 0.5` constant at module level
- Replaced 3x `asyncio.sleep(0.5)` with `asyncio.sleep(_RETRY_DELAY)`

### Test results

All **144 tests pass**, pylint 10.00/10.