### PR TITLE
Format long __init__ signatures to multi-line (PEP 8)

### DIFF
--- a/src/pooldose/client.py
+++ b/src/pooldose/client.py
@@ -30,7 +30,19 @@ class PooldoseClient:
     All getter methods return (status, data) and log errors.
     """
 
-    def __init__(self, host: str, timeout: int = 30, *, websession: Optional[aiohttp.ClientSession] = None, include_sensitive_data: bool = False, include_mac_lookup: bool = False, use_ssl: bool = False, port: Optional[int] = None, ssl_verify: bool = True, debug_payload: bool = False) -> None:  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        host: str,
+        timeout: int = 30,
+        *,
+        websession: Optional[aiohttp.ClientSession] = None,
+        include_sensitive_data: bool = False,
+        include_mac_lookup: bool = False,
+        use_ssl: bool = False,
+        port: Optional[int] = None,
+        ssl_verify: bool = True,
+        debug_payload: bool = False,
+    ) -> None:
         """
         Initialize the Pooldose client.
 

--- a/src/pooldose/request_handler.py
+++ b/src/pooldose/request_handler.py
@@ -32,7 +32,17 @@ class RequestHandler:  # pylint: disable=too-many-instance-attributes
     Only softwareVersion, and apiversion are loaded from params.js.
     """
 
-    def __init__(self, host: str, timeout: int = 10, *, websession: Optional[aiohttp.ClientSession] = None, use_ssl: bool = False, port: Optional[int] = None, ssl_verify: bool = True, debug_payload: bool = False):  # pylint: disable=too-many-arguments
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        host: str,
+        timeout: int = 10,
+        *,
+        websession: Optional[aiohttp.ClientSession] = None,
+        use_ssl: bool = False,
+        port: Optional[int] = None,
+        ssl_verify: bool = True,
+        debug_payload: bool = False,
+    ):
         self.host = host
         self.timeout = timeout
         self.use_ssl = use_ssl


### PR DESCRIPTION
## Format long __init__ signatures to multi-line (PEP 8)

### Description

The `__init__` methods of `PooldoseClient` and `RequestHandler` had all parameters on a single line (200+ characters). This reformats them to one parameter per line for better readability, following PEP 8 line length guidelines.

### Changes

**src/pooldose/client.py**
- Reformatted `PooldoseClient.__init__()` signature (10 parameters) to multi-line

**src/pooldose/request_handler.py**
- Reformatted `RequestHandler.__init__()` signature (7 parameters) to multi-line

No functional changes. Existing `# pylint: disable=too-many-arguments` retained.

### Test results

All **144 tests pass**, pylint 10.00/10.