### PR TITLE
Fix session consistency in _get_core_params()

### DIFF
--- a/src/pooldose/request_handler.py
+++ b/src/pooldose/request_handler.py
@@ -164,11 +164,14 @@ class RequestHandler:  # pylint: disable=too-many-instance-attributes
         result = {}
         try:
             timeout_obj = aiohttp.ClientTimeout(total=self.timeout)
-            connector = self._get_ssl_connector()
-            async with aiohttp.ClientSession(connector=connector) as session:
+            session, close_session = await self._get_session()
+            try:
                 async with session.get(url, headers=self._headers, timeout=timeout_obj) as resp:
                     resp.raise_for_status()
                     js_text = await resp.text()
+            finally:
+                if close_session:
+                    await session.close()
 
             for key in keys:
                 match = re.search(rf'{key}\s*:\s*["\']([^"\']+)["\']', js_text)


### PR DESCRIPTION
## Fix session consistency in _get_core_params()

### Description

Follow-up to #23. The `_get_core_params()` method was missed in the original session consistency fix, it still created its own `aiohttp.ClientSession` instead of using `_get_session()`.

This means externally provided sessions (e.g. from Home Assistant's `aiohttp_client`) were bypassed during `connect()`, potentially causing resource leaks and inconsistent session behavior.

### Changes

**src/pooldose/request_handler.py**
- Replaced standalone `aiohttp.ClientSession(connector=connector)` with `await self._get_session()`
- Added proper `try/finally` block to close internally-created sessions
- External sessions are no longer closed by this method (matching all other request methods)

### Testing

- All **160 tests pass**, pylint 10.00/10
- Verified against real device (`PDPR1H1HAW102`, FW `539187`): `connect()` returns `SUCCESS`, `softwareVersion` and `apiversion` correctly extracted