### PR TITLE
Add broad exception handling in _get_core_params()

### DIFF
--- a/src/pooldose/request_handler.py
+++ b/src/pooldose/request_handler.py
@@ -185,6 +185,9 @@ class RequestHandler:  # pylint: disable=too-many-instance-attributes
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             _LOGGER.warning("Error fetching core params: %s", err)
             return None
+        except Exception as err:  # pylint: disable=broad-exception-caught
+            _LOGGER.warning("Unexpected error fetching core params: %s", err)
+            return None
 
     async def get_debug_config(self) -> Tuple[RequestStatus, Optional[DebugConfigDict]]:
         """


### PR DESCRIPTION
## Add broad exception handling in `_get_core_params()`

### Problem
The `except` clause in `_get_core_params()` only catches `aiohttp.ClientError` and `asyncio.TimeoutError`. If the Pooldose device returns malformed data (e.g. invalid UTF-8 encoding in `/js_libs/params.js`), a `UnicodeDecodeError` or other unexpected exception bubbles up uncaught and crashes the entire `connect()` flow.

This can occur during normal Home Assistant usage when the device has a firmware glitch or network corruption.

### Fix
Added a fallback `except Exception` block that logs the unexpected error and gracefully returns `None`, preventing `connect()` from crashing. The specific `aiohttp.ClientError` / `TimeoutError` handler is preserved for targeted logging.

The `pylint: disable=broad-exception-caught` annotation is intentional, this is a last-resort safety net to catch unexpected errors like `UnicodeDecodeError` from malformed device responses that fall outside the known `aiohttp` / `asyncio` exception hierarchy.

### Changes
- `src/pooldose/request_handler.py`: Added broad exception fallback in `_get_core_params()` with inline comment explaining the rationale

### Testing
- All 160 tests pass
- Pylint: 10.00/10