### PR TITLE
Add PDHC1H1HAR1V0 alias for VÁGNER POOL VA DOS BASIC

### DIFF
--- a/src/pooldose/constants.py
+++ b/src/pooldose/constants.py
@@ -7,6 +7,7 @@ from pooldose.type_definitions import DeviceInfoDict
 # in their data keys and mapping files.
 MODEL_ALIASES: dict[str, str] = {
     "PDHC1H1HAR1V1": "PDPR1H1HAR1V0",
+    "PDHC1H1HAR1V0": "PDPR1H1HAR1V0",  # VÁGNER POOL VA DOS BASIC (listed in device-support.md, see #41)
     "PDPR1H1HAW102": "PDPR1H1HAW100",
 }
 

--- a/src/pooldose/constants.py
+++ b/src/pooldose/constants.py
@@ -7,7 +7,7 @@ from pooldose.type_definitions import DeviceInfoDict
 # in their data keys and mapping files.
 MODEL_ALIASES: dict[str, str] = {
     "PDHC1H1HAR1V1": "PDPR1H1HAR1V0",
-    "PDHC1H1HAR1V0": "PDPR1H1HAR1V0",  # VÁGNER POOL VA DOS BASIC (listed in device-support.md, see #41)
+    "PDHC1H1HAR1V0": "PDPR1H1HAR1V0", 
     "PDPR1H1HAW102": "PDPR1H1HAW100",
 }
 


### PR DESCRIPTION
Adds PDHC1H1HAR1V0 → PDPR1H1HAR1V0 mapping to MODEL_ALIASES.

The device reports PRODUCT_CODE=PDHC1H1HAR1V0 (debug/config/info endpoint) but uses PDPR1H1HAR1V0_FW539224_ prefix for all telemetry keys.  With this alias, the existing model_PDPR1H1HAR1V0_FW539224.json mapping covers the device with no further changes.

Fixes #41