### PR TITLE
feat: add KEMI DOSE AQUAVIVA pH-ORP-CL support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.9] - 2026-08-17
+
+### Added
+
+- Added support for KEMI DOSE AQUAVIVA pH-ORP-CL (`KDHC5050AWH01`, firmware `539191`).
+  - Resolves the reported product code to the `KDPR5050AWH00` model used by the
+    device data keys.
+  - Added mapping coverage for temperature, pH, ORP, and chlorine measurements,
+    dosing type and mode, pH/ORP calibration, OFA timers, level and threshold
+    alarms, relay and status flags, setpoints, dosing timers, switches, and the
+    water meter unit.
+- Added regression tests for the KEMI DOSE AQUAVIVA model alias and mapping.
+
 ## [0.9.8] - 2026-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     dosing type and mode, pH/ORP calibration, OFA timers, level and threshold
     alarms, relay and status flags, setpoints, dosing timers, switches, and the
     water meter unit.
+  - This mapping also covers KEMI DOSE AQUAVIVA pH-ORP (`KDPR5050AWH00`,
+    firmware `539191`), the chlorine-less variant of the device that reports
+    its raw product code directly (untested).
 - Added regression tests for the KEMI DOSE AQUAVIVA model alias and mapping.
+
+### Contributors
+
+Thanks to [@vitalii-ch](https://github.com/vitalii-ch) for contributing to this release.
 
 ## [0.9.8] - 2026-08-17
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ See [docs/cli.md](docs/cli.md) for full CLI documentation and device analysis de
 | BWT Manager Connect Duo | PDPR1H1HAW1B0_I | 539472 | Uses PDPR1H1HAW1B0 data-key mapping |
 | VÁGNER POOL VA DOS BASIC | PDHC1H1HAR1V0 | 539224 | |
 | VÁGNER POOL VA DOS EXACT | PDHC1H1HAR1V1 | 539224 | Own dedicated mapping (incl. chlorine); raw data keys use PDPR1H1HAR1V0 prefix |
+| KEMI DOSE AQUAVIVA pH-ORP-CL | KDHC5050AWH01 | 539191 | pH/ORP/chlorine device; resolves to KDPR5050AWH00 data-key mapping |
 
 Other models may work but are untested. See [docs/device-support.md](docs/device-support.md) for how to request support for new devices.
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ See [docs/cli.md](docs/cli.md) for full CLI documentation and device analysis de
 | BWT Manager Connect Duo | PDPR1H1HAW1B0_I | 539472 | Uses PDPR1H1HAW1B0 data-key mapping |
 | VÁGNER POOL VA DOS BASIC | PDHC1H1HAR1V0 | 539224 | |
 | VÁGNER POOL VA DOS EXACT | PDHC1H1HAR1V1 | 539224 | Own dedicated mapping (incl. chlorine); raw data keys use PDPR1H1HAR1V0 prefix |
+| KEMI DOSE AQUAVIVA pH-ORP | KDPR5050AWH00 | 539191 | pH/ORP device (no chlorine); untested |
 | KEMI DOSE AQUAVIVA pH-ORP-CL | KDHC5050AWH01 | 539191 | pH/ORP/chlorine device; resolves to KDPR5050AWH00 data-key mapping |
 
 Other models may work but are untested. See [docs/device-support.md](docs/device-support.md) for how to request support for new devices.

--- a/docs/device-support.md
+++ b/docs/device-support.md
@@ -13,6 +13,7 @@ This client has been tested with:
 | BWT MEDO CONNECT Wi-Fi | PDPH1H1HAW1B0 | 539494 | pH-only device |
 | VÁGNER POOL VA DOS BASIC | PDHC1H1HAR1V0 | 539224 | Alias for PDPR1H1HAR1V0 mapping |
 | VÁGNER POOL VA DOS EXACT | PDHC1H1HAR1V1 | 539224 | Own dedicated mapping (incl. chlorine); raw data keys use PDPR1H1HAR1V0 prefix |
+| KEMI DOSE AQUAVIVA pH-ORP | KDPR5050AWH00 | 539191 | pH/ORP device (no chlorine); untested |
 | KEMI DOSE AQUAVIVA pH-ORP-CL | KDHC5050AWH01 | 539191 | pH/ORP/chlorine device; resolves to KDPR5050AWH00 mapping |
 
 Other SEKO or VÁGNER POOL models may work but are untested. The client uses JSON mapping files to adapt to different device models and firmware versions (see e.g. `src/pooldose/mappings/model_PDPR1H1HAW100_FW539187.json`).

--- a/docs/device-support.md
+++ b/docs/device-support.md
@@ -13,6 +13,7 @@ This client has been tested with:
 | BWT MEDO CONNECT Wi-Fi | PDPH1H1HAW1B0 | 539494 | pH-only device |
 | VÁGNER POOL VA DOS BASIC | PDHC1H1HAR1V0 | 539224 | Alias for PDPR1H1HAR1V0 mapping |
 | VÁGNER POOL VA DOS EXACT | PDHC1H1HAR1V1 | 539224 | Own dedicated mapping (incl. chlorine); raw data keys use PDPR1H1HAR1V0 prefix |
+| KEMI DOSE AQUAVIVA pH-ORP-CL | KDHC5050AWH01 | 539191 | pH/ORP/chlorine device; resolves to KDPR5050AWH00 mapping |
 
 Other SEKO or VÁGNER POOL models may work but are untested. The client uses JSON mapping files to adapt to different device models and firmware versions (see e.g. `src/pooldose/mappings/model_PDPR1H1HAW100_FW539187.json`).
 

--- a/src/pooldose/__init__.py
+++ b/src/pooldose/__init__.py
@@ -1,5 +1,5 @@
 """Async API client for SEKO Pooldose."""
 from .client import PooldoseClient
 
-__version__ = "0.9.8"
+__version__ = "0.9.9"
 __all__ = ["PooldoseClient"]

--- a/src/pooldose/constants.py
+++ b/src/pooldose/constants.py
@@ -18,6 +18,7 @@ MODEL_ALIASES: dict[str, str] = {
     "PDHC1H1HAR1V0": "PDPR1H1HAR1V0",
     "PDPR1H1HAW102": "PDPR1H1HAW100",
     "PDPR1H1HAW1B0_I": "PDPR1H1HAW1B0",
+    "KDHC5050AWH01": "KDPR5050AWH00",
 }
 
 # Default device info structure

--- a/src/pooldose/mappings/model_KDPR5050AWH00_FW539191.json
+++ b/src/pooldose/mappings/model_KDPR5050AWH00_FW539191.json
@@ -1,0 +1,272 @@
+{
+  "temperature": {
+    "key": "w_1eommf39k",
+    "type": "sensor"
+  },
+  "ph": {
+    "key": "w_1ekeigkin",
+    "type": "sensor"
+  },
+  "orp": {
+    "key": "w_1eklenb23",
+    "type": "sensor"
+  },
+  "cl": {
+    "key": "w_1eo03t46k",
+    "type": "sensor"
+  },
+  "ph_type_dosing": {
+    "key": "w_1eklg44ro",
+    "type": "sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklg44ro_ALCALYNE|": "alcalyne",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklg44ro_ACID|": "acid"
+    }
+  },
+  "peristaltic_ph_dosing": {
+    "key": "w_1eklj6euj",
+    "type": "sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklj6euj_OFF|": "off",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklj6euj_PROPORTIONAL|": "proportional",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklj6euj_ON_OFF|": "on / off"
+    }
+  },
+  "orp_type_dosing": {
+    "key": "w_1eklgnolb",
+    "type": "sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklgnolb_LOW|": "low",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklgnolb_HIGH|": "high"
+    }
+  },
+  "peristaltic_orp_dosing": {
+    "key": "w_1eo1s18s8",
+    "type": "sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eo1s18s8_OFF|": "off",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eo1s18s8_PROPORTIONAL|": "proportional",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eo1s18s8_ON_OFF|": "on / off"
+    }
+  },
+  "cl_type_dosing": {
+    "key": "w_1eo1sf02n",
+    "type": "sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eo1sf02n_LOW|": "low",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eo1sf02n_HIGH|": "high"
+    }
+  },
+  "peristaltic_cl_dosing": {
+    "key": "w_1eo1sf1m6",
+    "type": "sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eo1sf1m6_OFF|": "off",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eo1sf1m6_PROPORTIONAL|": "proportional",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eo1sf1m6_ON_OFF|": "on / off"
+    }
+  },
+  "ph_calibration_type": {
+    "key": "w_1eklh8gb7",
+    "type": "sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklh8gb7_OFF|": "off",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklh8gb7_REFERENCE|": "reference",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklh8gb7_1_POINT|": "1_point",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklh8gb7_2_POINTS|": "2_points"
+    }
+  },
+  "ph_calibration_offset": {
+    "key": "w_1eklhs3b4",
+    "type": "sensor"
+  },
+  "ph_calibration_slope": {
+    "key": "w_1eklhs65u",
+    "type": "sensor"
+  },
+  "orp_calibration_type": {
+    "key": "w_1eklh8i5t",
+    "type": "sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklh8i5t_OFF|": "off",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklh8i5t_REFERENCE|": "reference",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eklh8i5t_1_POINT|": "1_point"
+    }
+  },
+  "orp_calibration_offset": {
+    "key": "w_1eklhs8r3",
+    "type": "sensor"
+  },
+  "orp_calibration_slope": {
+    "key": "w_1eklhsase",
+    "type": "sensor"
+  },
+  "ofa_ph_time": {
+    "key": "w_1eo1ttmft",
+    "type": "sensor"
+  },
+  "ofa_orp_time": {
+    "key": "w_1eo1tui1d",
+    "type": "sensor"
+  },
+  "device_config": {
+    "key": "w_1eu61251u",
+    "type": "sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eu61251u_PH_ORP|": "ph_orp",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eu61251u_PH_ORP_CHLORINE|": "ph_orp_chlorine"
+    }
+  },
+  "temperature_unit": {
+    "key": "w_1fkpchru3",
+    "type": "sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1fkpchru3__C|": "celsius",
+      "|KDPR5050AWH00_FW539191_LABEL_w_1fkpchru3__F|": "fahrenheit"
+    }
+  },
+  "ph_level_alarm": {
+    "key": "w_1eklf77pm",
+    "type": "binary_sensor"
+  },
+  "flow_rate_alarm": {
+    "key": "w_1eo04nc5n",
+    "type": "binary_sensor"
+  },
+  "relay_alarm": {
+    "key": "w_1eklffdl0",
+    "type": "binary_sensor"
+  },
+  "relay_aux1": {
+    "key": "w_1eoi2rv4h",
+    "type": "binary_sensor"
+  },
+  "relay_aux2": {
+    "key": "w_1eoi2s16b",
+    "type": "binary_sensor"
+  },
+  "alarm_ofa_ph": {
+    "key": "w_1eklfb73r",
+    "type": "binary_sensor"
+  },
+  "alarm_ofa2_ph": {
+    "key": "w_1eklfb8ob",
+    "type": "binary_sensor"
+  },
+  "alarm_ofa_orp": {
+    "key": "w_1eo1pabt6",
+    "type": "binary_sensor"
+  },
+  "alarm_ofa2_orp": {
+    "key": "w_1eo1paejq",
+    "type": "binary_sensor"
+  },
+  "alarm_ofa_cl": {
+    "key": "w_1eo1pju7i",
+    "type": "binary_sensor"
+  },
+  "alarm_ofa2_cl": {
+    "key": "w_1eo1pk0kl",
+    "type": "binary_sensor"
+  },
+  "alarm_water_too_cold": {
+    "key": "w_1fi96raof",
+    "type": "binary_sensor"
+  },
+  "alarm_water_too_hot": {
+    "key": "w_1fi96rc28",
+    "type": "binary_sensor"
+  },
+  "alarm_ph_too_low": {
+    "key": "w_1fi96rd71",
+    "type": "binary_sensor"
+  },
+  "alarm_ph_too_high": {
+    "key": "w_1fi96retp",
+    "type": "binary_sensor"
+  },
+  "alarm_cl_too_low_orp": {
+    "key": "w_1fi96rg8f",
+    "type": "binary_sensor"
+  },
+  "alarm_cl_too_high_orp": {
+    "key": "w_1fi96rhsp",
+    "type": "binary_sensor"
+  },
+  "alarm_cl_too_high": {
+    "key": "w_1fi96rm5k",
+    "type": "binary_sensor"
+  },
+  "alarm_system_standby": {
+    "key": "w_1fi97ai42",
+    "type": "binary_sensor"
+  },
+  "circulation_pump_status": {
+    "key": "w_1eo2fpohe",
+    "type": "binary_sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eo2fpohe_DISABLED_|": false,
+      "|KDPR5050AWH00_FW539191_LABEL_w_1eo2fpohe_ENABLED|": true
+    }
+  },
+  "power_on_delay_status": {
+    "key": "w_1fi968rei",
+    "type": "binary_sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1fi968rei_DISABLE|": false,
+      "|KDPR5050AWH00_FW539191_LABEL_w_1fi968rei_ENABLE|": true
+    }
+  },
+  "flow_delay_status": {
+    "key": "w_1fi968tnu",
+    "type": "binary_sensor",
+    "conversion": {
+      "|KDPR5050AWH00_FW539191_LABEL_w_1fi968tnu_DISABLE|": false,
+      "|KDPR5050AWH00_FW539191_LABEL_w_1fi968tnu_ENABLE|": true
+    }
+  },
+  "ph_target": {
+    "key": "w_1ekeiqfat",
+    "type": "number"
+  },
+  "orp_target": {
+    "key": "w_1eklgnjk2",
+    "type": "number"
+  },
+  "cl_target": {
+    "key": "w_1eo1sejba",
+    "type": "number"
+  },
+  "power_on_delay_timer": {
+    "key": "w_1ffngb0e3",
+    "type": "number"
+  },
+  "flow_delay_timer": {
+    "key": "w_1ffngb253",
+    "type": "number"
+  },
+  "pause_dosing": {
+    "key": "w_1emtltkel",
+    "type": "switch"
+  },
+  "pump_monitoring": {
+    "key": "w_1eklft47q",
+    "type": "switch"
+  },
+  "frequency_input": {
+    "key": "w_1eklft5qt",
+    "type": "switch"
+  },
+  "water_meter_unit": {
+    "key": "w_1eklinki6",
+    "type": "select",
+    "options": {
+      "0": "KDPR5050AWH00_FW539191_COMBO_w_1eklinki6_M_",
+      "1": "KDPR5050AWH00_FW539191_COMBO_w_1eklinki6_LITER"
+    },
+    "conversion": {
+      "KDPR5050AWH00_FW539191_COMBO_w_1eklinki6_M_": "m3",
+      "KDPR5050AWH00_FW539191_COMBO_w_1eklinki6_LITER": "L"
+    }
+  }
+}

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -349,6 +349,45 @@ class TestModelAliases:
         assert client.device_info["MODEL_ID"] == "PDPR1H1HAW1B0_I"
 
     @pytest.mark.asyncio
+    async def test_connect_resolves_kemi_dose_aquaviva_alias(
+        self, mock_request_handler, mock_mapping_info
+    ):
+        """Test mapping resolution for KEMI DOSE AQUAVIVA pH-ORP-CL."""
+        client = PooldoseClient(host="192.168.3.158", retry_delay=0)
+        mock_request_handler.get_debug_config.return_value = (
+            RequestStatus.SUCCESS,
+            {
+                "GATEWAY": {"DID": "TEST551", "NAME": "ESP32 GATEWAY"},
+                "DEVICES": [{
+                    "DID": "TEST551_DEVICE",
+                    "NAME": "KEMI DOSE AQUAVIVA pH-ORP-CL",
+                    "PRODUCT_CODE": "KDHC5050AWH01",
+                    "FW_REL": "1.6",
+                    "FW_CODE": "539191",
+                }],
+            },
+        )
+        mock_request_handler.get_wifi_station.return_value = (
+            RequestStatus.SUCCESS,
+            {},
+        )
+        mock_request_handler.get_access_point.return_value = (RequestStatus.SUCCESS, {})
+        mock_request_handler.get_network_info.return_value = (RequestStatus.SUCCESS, {})
+
+        with patch("pooldose.client.RequestHandler", return_value=mock_request_handler):
+            with patch(
+                "pooldose.mappings.mapping_info.MappingInfo.load",
+                return_value=mock_mapping_info,
+            ) as mock_load:
+                status = await client.connect()
+
+        assert status == RequestStatus.SUCCESS
+        mock_load.assert_called_once_with(
+            "KDHC5050AWH01", "539191", fallback_model_id="KDPR5050AWH00"
+        )
+        assert client.device_info["MODEL_ID"] == "KDHC5050AWH01"
+
+    @pytest.mark.asyncio
     async def test_instant_values_uses_resolved_prefix(
         self, mock_request_handler, mock_device_info_aliased,
         mock_mapping_info, mock_raw_data_aliased

--- a/tests/test_mapping_info.py
+++ b/tests/test_mapping_info.py
@@ -305,3 +305,64 @@ class TestMappingFallbackResolution:
 
         assert mapping_info.status == RequestStatus.MAPPING_NOT_FOUND
         assert mapping_info.mapping is None
+
+
+class TestKemiDoseAquavivaMapping:  # pylint: disable=too-few-public-methods
+    """Tests for the KEMI DOSE AQUAVIVA pH-ORP-CL mapping file."""
+
+    @pytest.mark.asyncio
+    async def test_load_kemi_dose_aquaviva_mapping(self):
+        """Test that the KEMI DOSE AQUAVIVA mapping loads with expected entities."""
+        mapping_info = await MappingInfo.load("KDPR5050AWH00", "539191")
+
+        assert mapping_info.status == RequestStatus.SUCCESS
+        assert mapping_info.mapping is not None
+        assert set(mapping_info.available_sensors()) >= {
+            "temperature",
+            "ph",
+            "orp",
+            "cl",
+            "ph_type_dosing",
+            "peristaltic_ph_dosing",
+            "orp_type_dosing",
+            "peristaltic_orp_dosing",
+            "cl_type_dosing",
+            "peristaltic_cl_dosing",
+            "ph_calibration_type",
+            "orp_calibration_type",
+        }
+        assert set(mapping_info.available_binary_sensors()) >= {
+            "ph_level_alarm",
+            "flow_rate_alarm",
+            "alarm_ofa_cl",
+            "circulation_pump_status",
+            "power_on_delay_status",
+            "flow_delay_status",
+        }
+        assert set(mapping_info.available_numbers()) >= {
+            "ph_target",
+            "orp_target",
+            "cl_target",
+            "power_on_delay_timer",
+            "flow_delay_timer",
+        }
+        assert set(mapping_info.available_switches()) >= {
+            "pause_dosing",
+            "pump_monitoring",
+            "frequency_input",
+        }
+        assert set(mapping_info.available_selects()) >= {
+            "water_meter_unit",
+        }
+
+    @pytest.mark.asyncio
+    async def test_kemi_dose_aquaviva_entity_counts(self):
+        """Test the total entity counts for the KEMI DOSE AQUAVIVA mapping."""
+        mapping_info = await MappingInfo.load("KDPR5050AWH00", "539191")
+        types = mapping_info.available_types()
+
+        assert len(types.get("sensor", [])) == 20
+        assert len(types.get("binary_sensor", [])) == 22
+        assert len(types.get("number", [])) == 5
+        assert len(types.get("switch", [])) == 3
+        assert len(types.get("select", [])) == 1


### PR DESCRIPTION
## Summary

Adds support for the **KEMI DOSE AQUAVIVA pH-ORP-CL** dosing station — a pH/ORP/chlorine device.

- Reported product code: `KDHC5050AWH01`, firmware `539191`
- Raw instant-value data keys use the `KDPR5050AWH00` model prefix

Follows the same pattern as the recent BWT Manager Connect Duo contribution (alias + dedicated mapping file).

## Changes

- **`constants.py`** — resolve `KDHC5050AWH01 → KDPR5050AWH00` via `MODEL_ALIASES` so the raw-key prefix and mapping fallback match the device's data keys.
- **`mappings/model_KDPR5050AWH00_FW539191.json`** — new mapping (51 entries) covering exactly the entity keys consumed by the Home Assistant `pooldose` integration: temperature, pH, ORP and chlorine measurements; dosing type and mode; pH/ORP calibration; OFA timers; level and threshold alarms; relay and status flags; setpoints; dosing timers; switches; and the water meter unit.
- **`README.md` / `docs/device-support.md`** — documented the device.
- **`CHANGELOG.md`** — `0.9.9` entry; version bump in `__init__.py`.
- **`tests/`** — regression tests for the alias resolution and the mapping file.

## Verification

- Full test suite green (179 passed), pylint clean.
- Verified **end-to-end against a live device**: `connect()` succeeds, the mapping loads via the alias fallback, and all 51 values resolve.
- Additionally validated in **Home Assistant** (core `pooldose` integration, HA 2026.8.2) against the physical station: the device is correctly identified as "KEMI DOSE AQUAVIVA pH-ORP-CL" and all entities appear with correct names/values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)